### PR TITLE
Fix removing the blip zone & vehicle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -820,7 +820,6 @@ end)
 
 
 RegisterNetEvent('jl-carboost:client:failedBoosting', function ()
-    RemoveBlip(dropBlip)
     if zone then
         zone:destroy()
         zone = nil
@@ -830,6 +829,9 @@ RegisterNetEvent('jl-carboost:client:failedBoosting', function ()
         scratchpoint = nil
         inscratchPoint = false
     end
+    RemoveBlip(blipDisplay)
+    RemoveBlip(dropBlip)
+    DeleteEntity(carSpawned)
     carSpawned, carID, carmodel = nil, nil, nil
     isContractStarted = false
     QBCore.Functions.Notify(Lang:t("error.no_car"), "error")


### PR DESCRIPTION
When leaving the zone after starting a vin/boost car and radius blip would stay this fixes that.